### PR TITLE
Activate Dependabot to maintain required GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+
+version: 2
+updates:
+  # Maintain GitHub Action dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Small PR to activate Dependabot and have it regularly check the included GitHub Actions.