### PR TITLE
fix(10-042): Limit user lookups to "local" NSS passwd databases

### DIFF
--- a/plugins/modules/audit_ssh_authorizedkeys.py
+++ b/plugins/modules/audit_ssh_authorizedkeys.py
@@ -152,7 +152,8 @@ def run_module():
             line = line.split('#', 1)[0].strip()
             if not line:
                 continue
-            db, *backends = line.split()
+            tokens = line.split()
+            db, backends = tokens[0], tokens[1:]
             if db != 'passwd:':
                 continue
             for backend in backends:
@@ -197,7 +198,7 @@ def run_module():
                 module.fail_json(msg='SSHD configuration invalid (or insufficient privileges, try become_user=root become=yes)', **result)
 
             for cline in sshd_stdout.decode().splitlines():
-                conf = cline.split(maxsplit=1)
+                conf = cline.split(None, 1)
                 if conf[0] == 'authorizedkeyscommand' and conf[1] != 'none':
                     msg = 'AuthorizedKeysCommand is configured: "{}". Keys returned by this command are not audited.'.format(conf[1])
                     warnings.append(msg)

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -13,6 +13,7 @@ linux_allowed_ssh_nss_backends:
   - compat
   - db
   - systemd
+linux_allowed_ssh_ignored_nss_backends: []
 
 linux_allowed_login_users:
   - root

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -8,6 +8,12 @@ linux_allowed_ssh_authorized_keys: []
 
 linux_additional_ssh_authorized_keys: []
 
+linux_allowed_ssh_nss_backends:
+  - files
+  - compat
+  - db
+  - systemd
+
 linux_allowed_login_users:
   - root
 

--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -165,6 +165,7 @@
   adfinis.maintenance.audit_ssh_authorizedkeys:
     allowed: "{{ linux_allowed_ssh_authorized_keys + linux_additional_ssh_authorized_keys }}"
     limit_nss_backends: "{{ linux_allowed_ssh_nss_backends }}"
+    ignore_nss_backends: "{{ linux_allowed_ssh_ignored_nss_backends }}"
   check_mode: yes
 
 - <<: *task

--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -164,6 +164,7 @@
     name: "Security: SSH keys: Check for unknown or outdated keys for root and all users"
   adfinis.maintenance.audit_ssh_authorizedkeys:
     allowed: "{{ linux_allowed_ssh_authorized_keys + linux_additional_ssh_authorized_keys }}"
+    limit_nss_backends: "{{ linux_allowed_ssh_nss_backends }}"
   check_mode: yes
 
 - <<: *task


### PR DESCRIPTION
By default, only users from `files`, `compat`, `db` and `systemd` backends are enumerated.  If other backends are active, a warning is emitted.  This behavior can be customized with the new `limit_nss_backends` module parameter and the `linux_allowed_ssh_nss_backends` Ansible variable. Closes #28.

Also emits a warning if AuthorizedKeysCommand is enabled.