### PR TITLE
Fixes (10-041): display ip6 localhost as suspicious ip

### DIFF
--- a/plugins/modules/lastlogins.py
+++ b/plugins/modules/lastlogins.py
@@ -153,8 +153,8 @@ def run_module():
 
     last_logins = []
     bad_logins = []
-    # last -i shows 0.0.0.0 for local logins
-    allowed_ips = ['0.0.0.0']
+    # last -i shows 0.0.0.0 or ::1 for local logins
+    allowed_ips = ['0.0.0.0', '::1']
     if module.params['allowed_ips'] is not None:
         allowed_ips.extend(module.params['allowed_ips'])
 


### PR DESCRIPTION
For (10-041): checking for suspicious logins, root logins with ip6 localhost are listed as suspicious. I.e. some servers will display 
```
+root     pts/1        ::1              Thu May 26 00:13:38 2022 - Thu May 26 00:13:41 2022  (00:00)
```
Logins from "::1" should also be ignored as suspicious.

Closes #21 