### PR TITLE
feat(vars): New maintenance_(global/host)_exclude_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,26 @@ rhel01.example.org
 centos01.example.org
 ```
 
-Every checklist task (which may consist of more than one Ansible task) has a unique task ID in the form `XX-YYY` which `XX` being the checklist id and `YYY` being a consecutive number within the checklist. E.g. `10-042`.  These IDs can be used to exclude tasks from being applied to one or more hosts using the `maintenance_exclude_tasks` hostvar:
-
+Every checklist task (which may consist of more than one Ansible task) has a unique task ID in the form `XX-YYY` which `XX` being the checklist id and `YYY` being a consecutive number within the checklist. E.g. `10-042`.  These IDs can be used to exclude tasks from being applied to one or more hosts using the `maintenance_exclude_tasks` hostvar.
+To be able to easily exclude some checks globally in a playbook and some checks only on a host-level, the variable by default combines `maintenance_global_exclude_tasks` and `maintenance_host_exclude_tasks`:
 
 ```yaml
-maintenance_exclude_tasks:
+# Exclude tasks globally
+--- group_vars/all/maint.yml
+maintenance_global_exclude_tasks:
   - 10-042
+
+--- host_vars/my_host/maint.yml
+# Additionally exclude 11-023 only on one host
+maintenance_host_exclude_tasks:
   - 11-023
+  # 10-042 is implicitly excluded by above global statement
+
+--- host_vars/other_host/maint.yml
+# Explicitly ONLY exclude a task on my host
+maintenance_exclude_tasks:
+  - 11-023
+  # 10-042 will be included, global list doesn't apply
 ```
 
 Some of the checklists have additional options which can be

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
-maintenance_exclude_tasks: []
+maintenance_global_exclude_tasks: []
+maintenance_host_exclude_tasks: []
+maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"
 
 linux_serverlogs_root_alias: serverlogs@example.org
 

--- a/roles/maintenance_11_debian/defaults/main.yml
+++ b/roles/maintenance_11_debian/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
-maintenance_exclude_tasks: []
+maintenance_global_exclude_tasks: []
+maintenance_host_exclude_tasks: []
+maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"

--- a/roles/maintenance_12_ubuntu/defaults/main.yml
+++ b/roles/maintenance_12_ubuntu/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
-maintenance_exclude_tasks: []
+maintenance_global_exclude_tasks: []
+maintenance_host_exclude_tasks: []
+maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"
 
 # Define which version of Ubuntu the Upgrade is checked against
 # Possible options: all, devel, latest, lts, stable, supported, supported-esm, series, unsupported

--- a/roles/maintenance_15_rhel/defaults/main.yml
+++ b/roles/maintenance_15_rhel/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
-maintenance_exclude_tasks: []
+maintenance_global_exclude_tasks: []
+maintenance_host_exclude_tasks: []
+maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"

--- a/roles/maintenance_xx_template/defaults/main.yml
+++ b/roles/maintenance_xx_template/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
-maintenance_exclude_tasks: []
+maintenance_global_exclude_tasks: []
+maintenance_host_exclude_tasks: []
+maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"
 
 # Define defaults which can be overriden on a host-by-host basis


### PR DESCRIPTION
Add two new variables `maintenance_host_exclude_tasks` and `maintenance_global_exclude_tasks` and merge them per default in `maintenance_exclude_tasks`. I also documented it in the README :)

This shouldn't break anything existing but allows to disable some checks on a global scope and ohters on a local scope without having to implement some custom variable merging for each repository separately