### PR TITLE
feat(maintenance_10_linux): logrotate ignore lastlog

### DIFF
--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -29,9 +29,9 @@ linux_additional_allowed_login_ips: []
 
 linux_large_logfiles_prune:
   - /mnt
-
-linux_additional_large_logfiles_prune:
   - /var/log/lastlog
+  
+linux_additional_large_logfiles_prune: []
 
 # ... and use allowed_large_files to exclude single files or small directories from the result
 

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -30,7 +30,8 @@ linux_additional_allowed_login_ips: []
 linux_large_logfiles_prune:
   - /mnt
 
-linux_additional_large_logfiles_prune: []
+linux_additional_large_logfiles_prune:
+  - /var/log/lastlog
 
 # ... and use allowed_large_files to exclude single files or small directories from the result
 

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -29,7 +29,6 @@ linux_additional_allowed_login_ips: []
 
 linux_large_logfiles_prune:
   - /mnt
-  - /var/log/lastlog
   
 linux_additional_large_logfiles_prune: []
 
@@ -45,5 +44,6 @@ linux_allowed_large_files:
   - "/var/log/journal/"
   - "/var/lib/rpm/Packages$"
   - "/var/cache/yum/"
+  - "/var/log/lastlog"
 
 linux_additional_allowed_large_files: []

--- a/roles/maintenance_10_linux/defaults/main.yml
+++ b/roles/maintenance_10_linux/defaults/main.yml
@@ -29,7 +29,7 @@ linux_additional_allowed_login_ips: []
 
 linux_large_logfiles_prune:
   - /mnt
-  
+
 linux_additional_large_logfiles_prune: []
 
 # ... and use allowed_large_files to exclude single files or small directories from the result


### PR DESCRIPTION
As `/var/log/lastlog` should not be rotated, it can be excluded per default.
See: https://man7.org/linux/man-pages/man8/lastlog.8.html