### PR TITLE
fix: specify utf-8 decode to ensure Python2.7 compatibility

### DIFF
--- a/plugins/modules/audit_ssh_authorizedkeys.py
+++ b/plugins/modules/audit_ssh_authorizedkeys.py
@@ -191,7 +191,7 @@ def run_module():
         for backend in getent_backends:
             getent = subprocess.Popen(['/usr/bin/getent', 'passwd', '-s', backend], stdout=subprocess.PIPE)
             getent_stdout, _ = getent.communicate()
-            for line in getent_stdout.decode().splitlines():
+            for line in getent_stdout.decode('utf-8').splitlines():
                 users.add(GetentPwdEnt(*line.split(':', 6)))
 
     # Read the acutal ssh authorized_keys
@@ -210,7 +210,7 @@ def run_module():
             if sshd_configtest.returncode != 0:
                 module.fail_json(msg='SSHD configuration invalid (or insufficient privileges, try become_user=root become=yes)', **result)
 
-            for cline in sshd_stdout.decode().splitlines():
+            for cline in sshd_stdout.decode('utf-8').splitlines():
                 conf = cline.split(None, 1)
                 if conf[0] == 'authorizedkeyscommand' and conf[1] != 'none':
                     msg = 'AuthorizedKeysCommand is configured: "{}". Keys returned by this command are not audited.'.format(conf[1])

--- a/plugins/modules/find.py
+++ b/plugins/modules/find.py
@@ -196,7 +196,7 @@ def run_module():
     out, err = findproc.communicate()
 
     if findproc.returncode != 0:
-        result['stderr'] = err.decode()
+        result['stderr'] = err.decode('utf-8')
         module.fail_json(msg='find process exited with non-zero returncode.  Run with -vvv to view stderr', **result)
 
     result['found'] = []

--- a/plugins/modules/lastlogins.py
+++ b/plugins/modules/lastlogins.py
@@ -156,7 +156,7 @@ def run_module():
     out, err = lastproc.communicate()
 
     if lastproc.returncode != 0:
-        result['stderr'] = err.decode()
+        result['stderr'] = err.decode('utf-8')
         module.fail_json(msg='last process exited with non-zero returncode.  Run with -vvv to view stderr', **result)
 
     # Parse output and match against allowed or forbidden users and/or ips
@@ -168,7 +168,7 @@ def run_module():
     if module.params['allowed_ips'] is not None:
         allowed_ips.extend(module.params['allowed_ips'])
 
-    for line in out.decode().splitlines():
+    for line in out.decode('utf-8').splitlines():
         if line.startswith('reboot') or line[1:].startswith('tmp begins') or len(line) == 0:
             continue
         tokens = line.split(None, 3)


### PR DESCRIPTION
Encountered an issue while running this against an older OS which still only uses Python2.7, where this collection failed to parse files with UTF characters. Adding explicit declaration.