### PR TITLE
feat(11_debian): add support for deb822 sources, fixes #48

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -13,5 +13,3 @@ jobs:
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v24
-        with:
-          path: "${GITHUB_WORKSPACE}"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,6 +41,7 @@ tags:
 dependencies:
   ansible.posix: 1.4.0
   community.general: 1.3.6
+  adfinis.facts: 1.0.2
 
 # The URL of the originating SCM repository
 repository: https://github.com/adfinis/ansible-collection-maintenance

--- a/roles/maintenance_11_debian/defaults/main.yml
+++ b/roles/maintenance_11_debian/defaults/main.yml
@@ -3,3 +3,14 @@
 maintenance_global_exclude_tasks: []
 maintenance_host_exclude_tasks: []
 maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"
+
+debian_sources_list_security_uri: http://security.debian.org/debian-security
+debian_sources_list_security_suite: >-
+  {%- if ansible_facts.distribution_major_version|int < 11 -%}
+  {{- ansible_facts.distribution_release -}}/updates
+  {%- else -%}
+  {{- ansible_facts.distribution_release -}}-security
+  {%- endif -%}
+
+# Repositories for which to ignore the use of release names such as "stable"
+debian_release_name_ignore_uris: []

--- a/roles/maintenance_11_debian/defaults/main.yml
+++ b/roles/maintenance_11_debian/defaults/main.yml
@@ -5,8 +5,8 @@ maintenance_host_exclude_tasks: []
 maintenance_exclude_tasks: "{{ maintenance_global_exclude_tasks + maintenance_host_exclude_tasks }}"
 
 debian_sources_list_security_uri: http://security.debian.org/debian-security
-debian_sources_list_security_suite: >-
-  {%- if ansible_facts.distribution_major_version|int < 11 -%}
+debian_sources_list_security_suite: |-
+  {%- if ansible_facts.distribution_major_version | int < 11 -%}
   {{- ansible_facts.distribution_release -}}/updates
   {%- else -%}
   {{- ansible_facts.distribution_release -}}-security

--- a/roles/maintenance_11_debian/tasks/main.yml
+++ b/roles/maintenance_11_debian/tasks/main.yml
@@ -12,42 +12,41 @@
     taskid: ignore-me
     name: bar
 
-- name: Load release-specific variables
-  ansible.builtin.include_vars: "{{ item }}"
-  with_first_found:
-    - "debian_{{ ansible_facts.distribution_major_version }}.yml"
-
+- name: Gather apt_sources facts
+  adfinis.facts.apt_sources_facts: {}
 
 - <<: *task
   vars:
     taskid: 11-011
     name: "Security: Are the security updates in the sources.list?"
   check_mode: yes
-  ansible.builtin.apt_repository:
-    repo: "{{ debian_sources_list_security | default(debian_sources_list_security_default) }}"
-
-- <<: *task
-  vars:
-    taskid: 11-012
-    name: "Repository: Check if repository is set to release name (e.g. 'bullseye') and not to 'stable' | Find all sources.list files"
-  ansible.builtin.find:
-    paths:
-      - /etc/apt/sources.list.d
-    patterns: ['*.list']
-  register: debian_sources_list_files
+  ansible.builtin.assert:
+    that: >-
+      ansible_facts.apt_sources
+      | selectattr('uri', 'eq', debian_sources_list_security_uri)
+      | selectattr('suites', 'contains', debian_sources_list_security_suite)
+      | selectattr('types', 'contains', 'deb')
+      | selectattr('components', 'contains', 'main')
+      | length > 0
+    fail_msg: >-
+      debian-security repository missing: deb {{ debian_sources_list_security_uri }} {{ debian_sources_list_security_suite }} main
+  changed_when: task.failed
+  failed_when: no
 
 - <<: *task
   vars:
     taskid: 11-012
     name: "Repository: Check if repository is set to release name (e.g. 'bullseye') and not to 'stable' | Check all sources.list files"
+    source_entry: "{{ item.1.filename }}: {{ item.1.uri }} {{ item.1.suites }} -> {{ ansible_facts.distribution_release }}"
   check_mode: yes
-  ansible.builtin.replace:
-    path: "{{ item.1 }}"
-    regexp: "(://[^\\s]+\\s+){{ item.0 }}\\b"
-    replace: "\\1{{ ansible_facts.distribution_release }}"
+  ansible.builtin.debug:
+    msg: "{{ source_entry }}"
+  changed_when:
+    - "item.0 in item.1.suites"
+    - "item.1.uri not in debian_release_name_ignore_uris"
   with_nested:
     - [stable, oldstable, oldoldstable]
-    - "{{ ['/etc/apt/sources.list'] + (debian_sources_list_files.files | map(attribute='path') | list) }}"
+    - "{{ ansible_facts.apt_sources }}"
 
 - <<: *task
   vars:
@@ -64,16 +63,24 @@
   vars:
     taskid: 11-013
     name: "For old distributions, has the repository been moved to http://archive.debian.org/ already? | grep sources.list"
-  ansible.builtin.lineinfile:
-    path: /etc/apt/sources.list
-    line: "deb http://archive.debian.org/debian/ {{ ansible_facts.distribution_release }} main contrib non-free"
-    regexp: "^\\s+deb[^-].*\\s+http://archive.debian.org/debian/?\\s+{{ ansible_facts.distribution_release }}\\s+.*$"
+  ansible.builtin.assert:
+    that: >-
+      ansible_facts.apt_sources
+      | selectattr('types', 'contains', 'deb')
+      | selectattr('uri', 'eq', 'http://archive.debian.org/debian/')
+      | selectattr('suites', 'contains', ansible_facts.distribution_release)
+      | selectattr('components', 'contains', 'main')
+      | length > 0
+    msg: >-
+      Distribution has moved to archive.debian.org.  Apt sources need to be updated:
+      deb http://archive.debian.org/debian/ {{ ansible_facts.distribution_release }} main
   # Even though this task runs all the time, the second changed_when rule causes it to only report a diff if running
   # on a distribution actually present on archive.debian.org.  Since the task is running in check mode, it doesn't do any
   # damage on non-archived distros, but won't report as changed.
   check_mode: yes
+  failed_when: no
   changed_when:
-    - "task.changed"
+    - "task.failed"
     - "debian_archive_repo_url.status == 200"
 
 - <<: *task

--- a/roles/maintenance_11_debian/vars/debian_10.yml
+++ b/roles/maintenance_11_debian/vars/debian_10.yml
@@ -1,3 +1,0 @@
----
-
-debian_sources_list_security_default: deb http://security.debian.org/debian-security buster/updates main

--- a/roles/maintenance_11_debian/vars/debian_11.yml
+++ b/roles/maintenance_11_debian/vars/debian_11.yml
@@ -1,3 +1,0 @@
----
-
-debian_sources_list_security_default: deb http://security.debian.org/debian-security bullseye-security main

--- a/roles/maintenance_11_debian/vars/debian_12.yml
+++ b/roles/maintenance_11_debian/vars/debian_12.yml
@@ -1,3 +1,0 @@
----
-
-debian_sources_list_security_default: deb http://security.debian.org/debian-security bookworm-security main

--- a/roles/maintenance_11_debian/vars/debian_9.yml
+++ b/roles/maintenance_11_debian/vars/debian_9.yml
@@ -1,3 +1,0 @@
----
-
-debian_sources_list_security_default: deb http://security.debian.org/debian-security stretch/updates main

--- a/roles/maintenance_11_debian/vars/debian_testing.yml
+++ b/roles/maintenance_11_debian/vars/debian_testing.yml
@@ -1,3 +1,0 @@
----
-
-debian_sources_list_security_default: deb http://security.debian.org/debian-security testing-security main


### PR DESCRIPTION
With Debian moving from the single-line sources.list format to the deb822 format, we need to support both when analyzing apt sources. For that, I created a facts plugin, which needs to be merged first: adfinis/adfinis.facts#3.

This PR also implements the feature requested in #48; where you can disable the 11-012 check for certain repos.