### PR TITLE
Don't use fixed dependencies for collections

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -39,8 +39,8 @@ tags:
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  ansible.posix: 1.4.0
-  community.general: 1.3.6
+  ansible.posix: ">=1.4.0"
+  community.general: ">=1.3.6"
   adfinis.facts: 1.0.2
 
 # The URL of the originating SCM repository

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,7 +41,7 @@ tags:
 dependencies:
   ansible.posix: ">=1.4.0"
   community.general: ">=1.3.6"
-  adfinis.facts: 1.0.2
+  adfinis.facts: ">=1.0.2"
 
 # The URL of the originating SCM repository
 repository: https://github.com/adfinis/ansible-collection-maintenance


### PR DESCRIPTION
Loosen up collection version requirements to have a better chance of using multiple collections in a playbook, that have same dependencies. This applies particularly for common collections, like ansible.posix or community.general.