### PR TITLE
feat: check for gpg errors in apt

### DIFF
--- a/roles/maintenance_11_debian/tasks/main.yml
+++ b/roles/maintenance_11_debian/tasks/main.yml
@@ -95,7 +95,7 @@
   vars:
     taskid: 11-015
     name: "GPG-Keys: Are there errors because of not existing GPG Keys?"
-  ansible.builtin.shell: apt-get update | grep -e 'Key is stored in legacy trusted.gpg keyring' -e 'GPG error:'  # noqa risky-shell-pipe
+  ansible.builtin.shell: apt-get update 2>&1 | grep -e 'Key is stored in legacy trusted.gpg keyring' -e 'GPG error:'  # noqa risky-shell-pipe
   register: debian_apt_update_status
   changed_when: no
   check_mode: no
@@ -106,8 +106,8 @@
     taskid: 11-015
     name: "GPG-Keys: Are there errors because of not existing GPG Keys? | Report errors"
   ansible.builtin.debug:
-    var: "debian_apt_update_status.stderr_lines"
-  changed_when: "debian_apt_update_status.stderr_lines | length > 0"
+    var: "debian_apt_update_status.stdout_lines"
+  changed_when: "debian_apt_update_status.stdout_lines | length > 0"
 
 - <<: *task
   vars:

--- a/roles/maintenance_11_debian/tasks/main.yml
+++ b/roles/maintenance_11_debian/tasks/main.yml
@@ -96,6 +96,8 @@
     taskid: 11-015
     name: "GPG-Keys: Are there errors because of not existing GPG Keys?"
   ansible.builtin.shell: apt-get update 2>&1 | grep -e 'Key is stored in legacy trusted.gpg keyring' -e 'GPG error:'  # noqa risky-shell-pipe
+  environment:
+    LC_ALL: C
   register: debian_apt_update_status
   changed_when: no
   check_mode: no

--- a/roles/maintenance_11_debian/tasks/main.yml
+++ b/roles/maintenance_11_debian/tasks/main.yml
@@ -93,6 +93,24 @@
 
 - <<: *task
   vars:
+    taskid: 11-015
+    name: "GPG-Keys: Are there errors because of not existing GPG Keys?"
+  ansible.builtin.shell: apt-get update | grep -e 'Key is stored in legacy trusted.gpg keyring' -e 'GPG error:'  # noqa risky-shell-pipe
+  register: debian_apt_update_status
+  changed_when: no
+  check_mode: no
+  failed_when: "debian_apt_update_status.rc not in [0, 1]"
+
+- <<: *task
+  vars:
+    taskid: 11-015
+    name: "GPG-Keys: Are there errors because of not existing GPG Keys? | Report errors"
+  ansible.builtin.debug:
+    var: "debian_apt_update_status.stderr_lines"
+  changed_when: "debian_apt_update_status.stderr_lines | length > 0"
+
+- <<: *task
+  vars:
     taskid: 11-016
     name: "dpkg status: Are there packages which do not have the dpkg status ii or hi? | Get list of matching packages"
   ansible.builtin.shell: dpkg -l | tail -n +6 | grep -vE '^[hi]i'  # noqa risky-shell-pipe  never fails


### PR DESCRIPTION
Hi again,

This PR add the task `11-015` to check if there is an error with gpg if you execute `apt-get update`.

Unfortunately I had to make this one a shell task. I tried to get the output from [this task](https://github.com/adfinis/ansible-collection-maintenance/blob/d60116a8c73b596a5b0c01a29b53826dfffa8886/roles/maintenance_11_debian/tasks/main.yml#L88) but for some reason the apt cache wasn't updated on each run even when I set `cache_valid_time: 0`.