### PR TITLE
feat: add possibility for cidr in last login

### DIFF
--- a/plugins/modules/lastlogins.py
+++ b/plugins/modules/lastlogins.py
@@ -166,13 +166,10 @@ def run_module():
     # last -i shows 0.0.0.0 for local logins
     allowed_ips = ['0.0.0.0']
     if module.params['allowed_ips'] is not None:
-        for allowed_ip in module.params['allowed_ips']:
-            allowed_ips.extend([str(ip) for ip in ipaddress.IPv4Network(allowed_ip)])
-
+        allowed_ips.extend(module.params['allowed_ips'])
     forbidden_ips = []
     if module.params['forbidden_ips'] is not None:
-        for forbidden_ip in module.params['forbidden_ips']:
-            forbidden_ips.extend([str(ip) for ip in ipaddress.IPv4Network(forbidden_ip)])
+        forbidden_ips.extend(module.params['forbidden_ips'])
 
     for line in out.decode('utf-8').splitlines():
         if line.startswith('reboot') or line[1:].startswith('tmp begins') or len(line) == 0:
@@ -188,9 +185,9 @@ def run_module():
             bad_logins.append(line)
         elif module.params['forbidden_users'] is not None and user in module.params['forbidden_users']:
             bad_logins.append(line)
-        elif ip not in allowed_ips:
+        elif not any(ipaddress.ip_address(ip) in ipaddress.ip_network(allowed_ip) for allowed_ip in allowed_ips):
             bad_logins.append(line)
-        elif ip in forbidden_ips:
+        elif any(ipaddress.ip_address(ip) in ipaddress.ip_network(forbidden_ip) for forbidden_ip in forbidden_ips):
             bad_logins.append(line)
 
     result['last_logins'] = last_logins

--- a/plugins/modules/lastlogins.py
+++ b/plugins/modules/lastlogins.py
@@ -47,12 +47,12 @@ options:
         default: null
         type: list
     allowed_ips:
-        description: List of source IPs from which log in is allowed.
+        description: List of source IPs (or CIDR ranges) from which log in is allowed.
         required: false
         default: null
         type: list
     forbidden_ips:
-        description: List of source IPs from which log in is forbidden.
+        description: List of source IPs (or CIDR ranges) from which log in is forbidden.
         required: false
         default: null
         type: list


### PR DESCRIPTION
Implementing feature request from [#50](https://git.adfinis.com/ch-classicit/maintenance-ansible-automation/-/issues/50).

Allows for the entries `allowed_ips`/`forbidden_ips` in lastlogin to be either a single ip or a cidr range.