### PR TITLE
fix: make sure when condition doesnt break maintenance_only

### DIFF
--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -154,7 +154,10 @@
     name: "Logrotate: Are there large files that point to a too verbose service?"
   ansible.builtin.debug:
     msg: "List of unrotated logs: {{ unmanaged_logs }}"
-  when: "unmanaged_logs | length > 0"
+  when:
+    - "vars.taskid not in maintenance_exclude_tasks"
+    - "maintenance_only is not defined or maintenance_only == vars.taskid"
+    - "unmanaged_logs | length > 0"
   changed_when: "unmanaged_logs | length > 0"
 
 - <<: *task
@@ -230,8 +233,9 @@
     line: "root: {{ linux_serverlogs_root_alias }}"
     insertbefore: EOF
   when:
-    - "'postfix' in ansible_facts.packages"
     - "vars.taskid not in maintenance_exclude_tasks"
+    - "maintenance_only is not defined or maintenance_only == vars.taskid"
+    - "'postfix' in ansible_facts.packages"
   check_mode: true
 
 - <<: *task
@@ -239,7 +243,10 @@
     taskid: 10-051
     name: "Mail: aliases.db: Make sure /etc/aliases.db is up to date"
   ansible.builtin.shell: "[ -f /etc/aliases ] && postalias /etc/aliases || exit 2"
-  when: "'postfix' in ansible_facts.packages"
+  when:
+    - "vars.taskid not in maintenance_exclude_tasks"
+    - "maintenance_only is not defined or maintenance_only == vars.taskid"
+    - "'postfix' in ansible_facts.packages"
   changed_when: "task.rc == 2"  # rc == 2 => file doesn't exist
   failed_when: "task.rc == 1"  # rc == 1 => postalias failed
 
@@ -249,7 +256,10 @@
     name: "Netboxinventory: Make sure pkg list is populated"
   ansible.builtin.fail:
     msg: "Error: Pkg list from host is empty"
-  when: "ansible_facts.packages | length == 0"
+  when:
+    - "vars.taskid not in maintenance_exclude_tasks"
+    - "maintenance_only is not defined or maintenance_only == vars.taskid"
+    - "ansible_facts.packages | length == 0"
 
 - <<: *task
   vars:

--- a/roles/maintenance_31_nginx/tasks/main.yml
+++ b/roles/maintenance_31_nginx/tasks/main.yml
@@ -109,6 +109,9 @@
     name: "SSL: If in use, will SSL certificate be valid in a month"
   ansible.builtin.debug:
     msg: "{{ item.not_after }}: {{ item.subject }}"
-  when: not (item.valid_at.one_month_later | default(true))
+  when:
+    - "vars.taskid not in maintenance_exclude_tasks"
+    - "maintenance_only is not defined or maintenance_only == vars.taskid"
+    - not (item.valid_at.one_month_later | default(true))
   changed_when: true
   loop: "{{ nginx_cert_info.results }}"


### PR DESCRIPTION
Hi,

I found a few cases where the `when` condition overwrites the defaults provided by the yaml anchor. 
This unfortunately breaks the `maintenance_only` behavior if you want to execute a single task only.

Also I'm curios why this inclusion / exclusion pattern is solved by when conditions. Couldn't we use tags for this?