### PR TITLE
fix: become false not respected when ansible-become variable is defined

### DIFF
--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -266,6 +266,7 @@
   vars:
     taskid: 10-067
     name: "Netboxinventory: Output pkg list to json"
+    ansible_become: false
   delegate_to: localhost
   become: false
   diff: false


### PR DESCRIPTION
Fixes the following

If one defines the variable `ansible-become` as `true`, the option `become: false` on a task level is ignored/overwritten.

![image](https://github.com/user-attachments/assets/5ea2aec4-61ca-4995-a328-6270a3178959)
