### PR TITLE
fix: logrotate parsing to actually remove managed logs from being flagged

### DIFF
--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -128,7 +128,7 @@
     taskid: 10-037
     name: "Logrotate: Are there large files that point to a too verbose service?"
   ansible.builtin.set_fact:
-    logrotate_logs: "{{ logrotate_output.content | b64decode | split('\n') }}"
+    logrotate_logs: "{{ logrotate_output.content | b64decode | split('\n') | map('split',' ') | map('first') |map('trim', '\"') | list }}"
 
 - <<: *task
   vars:
@@ -141,20 +141,21 @@
     pattern: "*.log"
     exclude: "{{ linux_allowed_large_files + linux_additional_allowed_large_files }}"
   register: all_logs
+  changed_when: False
 
 - <<: *task
   vars:
     taskid: 10-037
     name: "Logrotate: Are there large files that point to a too verbose service?"
   ansible.builtin.set_fact:
-    unmanaged_logs: "{{ all_logs.found | reject('in', (logrotate_output.content | b64decode)) | list }}"
+    unmanaged_logs: "{{ all_logs.found | reject('in', logrotate_logs) | list }}"
 
 - <<: *task
   vars:
     taskid: 10-037
     name: "Logrotate: Are there large files that point to a too verbose service?"
   ansible.builtin.debug:
-    msg: "List of unrotated logs: {{ unmanaged_logs }}"
+    msg: "List of logs not managed by logrotate: \n{% for item in unmanaged_logs %}{{ item + '\n'}}{% endfor %}"
   when:
     - "vars.taskid not in maintenance_exclude_tasks"
     - "maintenance_only is not defined or maintenance_only == vars.taskid"

--- a/roles/maintenance_10_linux/tasks/main.yml
+++ b/roles/maintenance_10_linux/tasks/main.yml
@@ -141,7 +141,7 @@
     pattern: "*.log"
     exclude: "{{ linux_allowed_large_files + linux_additional_allowed_large_files }}"
   register: all_logs
-  changed_when: False
+  changed_when: false
 
 - <<: *task
   vars:

--- a/roles/maintenance_10_linux/vars/RedHat7.yml
+++ b/roles/maintenance_10_linux/vars/RedHat7.yml
@@ -1,3 +1,4 @@
 ---
 
+linux_logrotate_status_file: "/var/lib/logrotate/logrotate.status"
 # linux_allowed_login_since: not supported in RHEL 7


### PR DESCRIPTION
The content of logrotate contains a line per log file in the structure `"log file" timestamp`.
The previous implementation compared those strings directly to a list of only file names, leading to no file getting removed from the list and all files in /var/log showing up in the task output.

Also made the output a bit more readable.