### PR TITLE
fix: indentation and remove unneded parentheses

### DIFF
--- a/roles/maintenance_31_nginx/tasks/main.yml
+++ b/roles/maintenance_31_nginx/tasks/main.yml
@@ -94,11 +94,11 @@
       one_month_later: "+1m"
   register: nginx_cert_info
   loop: >-
-     {%- set cert_content = [] -%}
-     {%- for result in nginx_cert_files_content.results -%}
-     {%- set cert_content = cert_content + ([(result.content | b64decode | community.crypto.split_pem)] | flatten) -%}
-     {%- endfor -%}
-     {{- cert_content -}}
+    {%- set cert_content = [] -%}
+    {%- for result in nginx_cert_files_content.results -%}
+    {%- set cert_content = cert_content + ([result.content | b64decode | community.crypto.split_pem] | flatten) -%}
+    {%- endfor -%}
+    {{- cert_content -}}
   changed_when: false
   ignore_errors: true
   delegate_to: localhost

--- a/roles/maintenance_32_apache/tasks/main.yml
+++ b/roles/maintenance_32_apache/tasks/main.yml
@@ -193,7 +193,7 @@
   loop: >-
     {%- set cert_content = [] -%}
     {%- for result in apache_cert_files_content.results -%}
-    {%- set cert_content = cert_content + ([(result.content | b64decode | community.crypto.split_pem)] | flatten) -%}
+    {%- set cert_content = cert_content + ([result.content | b64decode | community.crypto.split_pem] | flatten) -%}
     {%- endfor -%}
     {{- cert_content -}}
   changed_when: false


### PR DESCRIPTION
fixing two warnings that popped up in the Github actions run and fix the indentation to align to 2 spaces.